### PR TITLE
Fix EF Core metadata key

### DIFF
--- a/src/DistributedFileStorage.Core/ChunkMetadata.cs
+++ b/src/DistributedFileStorage.Core/ChunkMetadata.cs
@@ -1,10 +1,12 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace DistributedFileStorage.Core;
 
 public class ChunkMetadata
 {
     public Guid FileId { get; set; }
+    [Key]
     public Guid ChunkId { get; set; }
     public int ChunkIndex { get; set; }
     public string Checksum { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- mark `ChunkMetadata.ChunkId` as the primary key so EF Core can track it

## Testing
- `dotnet` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_6884caea905c832481db03611d8a24e3