### PR TITLE
Fix rebuild file extension preservation

### DIFF
--- a/src/DistributedFileStorage.Core/ChunkMetadata.cs
+++ b/src/DistributedFileStorage.Core/ChunkMetadata.cs
@@ -10,6 +10,7 @@ public class ChunkMetadata
     public Guid FileId { get; set; }
     [Key]
     public Guid ChunkId { get; set; }
+    public string OriginalFileName { get; set; } = string.Empty;
     public int ChunkIndex { get; set; }
     public string Checksum { get; set; } = string.Empty;
     public string StorageProviderName { get; set; } = string.Empty;

--- a/src/DistributedFileStorage.Infrastructure/FileRebuilder.cs
+++ b/src/DistributedFileStorage.Infrastructure/FileRebuilder.cs
@@ -26,8 +26,12 @@ public class FileRebuilder : IFileRebuilder
             .ToList();
         if (!metadataList.Any())
             throw new InvalidOperationException($"No chunks found for file {fileId}");
-
-        var outputPath = Path.Combine(targetDirectory, fileId.ToString());
+        var originalName = metadataList.First().OriginalFileName;
+        var extension = Path.GetExtension(originalName);
+        var fileName = string.IsNullOrWhiteSpace(extension)
+            ? fileId.ToString()
+            : $"{fileId}{extension}";
+        var outputPath = Path.Combine(targetDirectory, fileName);
         await using var output = File.Create(outputPath);
 
         foreach (var chunk in metadataList)

--- a/src/DistributedFileStorage.Infrastructure/FileUploadService.cs
+++ b/src/DistributedFileStorage.Infrastructure/FileUploadService.cs
@@ -32,6 +32,7 @@ public class FileUploadService
             {
                 FileId = chunk.FileId,
                 ChunkId = chunk.Id,
+                OriginalFileName = chunk.OriginalFileName,
                 ChunkIndex = chunk.ChunkIndex,
                 Checksum = chunk.Checksum,
                 StorageProviderName = provider.Name,


### PR DESCRIPTION
## Summary
- store original file name in `ChunkMetadata`
- record `OriginalFileName` during upload
- use the extension when rebuilding a file

## Testing
- `apt-get update` *(fails: repository unsigned)*
- `dotnet --version` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852cb2614c8324bccdebd4cb454a17